### PR TITLE
添加CPU端性能分析工具

### DIFF
--- a/engine/source/runtime/function/render/passes/directional_light_pass.cpp
+++ b/engine/source/runtime/function/render/passes/directional_light_pass.cpp
@@ -4,6 +4,7 @@
 #include "runtime/function/render/rhi/vulkan/vulkan_util.h"
 
 #include "runtime/function/render/passes/directional_light_pass.h"
+#include "runtime/function/utils/profiler.h"
 
 #include <mesh_directional_light_shadow_frag.h>
 #include <mesh_directional_light_shadow_vert.h>
@@ -480,6 +481,7 @@ namespace Piccolo
         std::map<VulkanPBRMaterial*, std::map<VulkanMesh*, std::vector<MeshNode>>>
             directional_light_mesh_drawcall_batch;
 
+        Profiler::begin("reorganize mesh");
         // reorganize mesh
         for (RenderMeshNode& node : *(m_visiable_nodes.p_directional_light_visible_mesh_nodes))
         {
@@ -499,6 +501,7 @@ namespace Piccolo
 
             mesh_nodes.push_back(temp);
         }
+        Profiler::end();
 
         // Directional Light Shadow begin pass
         {
@@ -529,6 +532,7 @@ namespace Piccolo
             }
         }
 
+        Profiler::begin("draw mesh");
         // Mesh
         if (m_vulkan_rhi->isPointLightShadowEnabled())
         {
@@ -722,6 +726,7 @@ namespace Piccolo
                 m_vulkan_rhi->m_vk_cmd_end_debug_utils_label_ext(m_vulkan_rhi->m_current_command_buffer);
             }
         }
+        Profiler::end();
 
         // Directional Light Shadow end pass
         {

--- a/engine/source/runtime/function/render/passes/main_camera_pass.cpp
+++ b/engine/source/runtime/function/render/passes/main_camera_pass.cpp
@@ -5,6 +5,7 @@
 
 #include "runtime/function/render/rhi/vulkan/vulkan_rhi.h"
 #include "runtime/function/render/rhi/vulkan/vulkan_util.h"
+#include "runtime/function/utils/profiler.h"
 
 #include <map>
 #include <stdexcept>
@@ -2232,8 +2233,9 @@ namespace Piccolo
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "BasePass", {1.0f, 1.0f, 1.0f, 1.0f}};
             m_vulkan_rhi->m_vk_cmd_begin_debug_utils_label_ext(m_vulkan_rhi->m_current_command_buffer, &label_info);
         }
-
+        Profiler::begin("drawMeshGbuffer");
         drawMeshGbuffer();
+        Profiler::end();
 
         if (m_vulkan_rhi->isDebugLabelEnabled())
         {
@@ -2248,8 +2250,9 @@ namespace Piccolo
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "Deferred Lighting", {1.0f, 1.0f, 1.0f, 1.0f}};
             m_vulkan_rhi->m_vk_cmd_begin_debug_utils_label_ext(m_vulkan_rhi->m_current_command_buffer, &label_info);
         }
-
+        Profiler::begin("drawDeferredLighting");
         drawDeferredLighting();
+        Profiler::end();
 
         if (m_vulkan_rhi->isDebugLabelEnabled())
         {
@@ -2264,8 +2267,9 @@ namespace Piccolo
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "Forward Lighting", {1.0f, 1.0f, 1.0f, 1.0f}};
             m_vulkan_rhi->m_vk_cmd_begin_debug_utils_label_ext(m_vulkan_rhi->m_current_command_buffer, &label_info);
         }
-
+        Profiler::begin("drawBillboardParticle");
         drawBillboardParticle();
+        Profiler::end();
 
         if (m_vulkan_rhi->isDebugLabelEnabled())
         {
@@ -2273,13 +2277,14 @@ namespace Piccolo
         }
 
         m_vulkan_rhi->m_vk_cmd_next_subpass(m_vulkan_rhi->m_current_command_buffer, VK_SUBPASS_CONTENTS_INLINE);
-
+        Profiler::begin("tone_mapping_pass");
         tone_mapping_pass.draw();
+        Profiler::end();
 
         m_vulkan_rhi->m_vk_cmd_next_subpass(m_vulkan_rhi->m_current_command_buffer, VK_SUBPASS_CONTENTS_INLINE);
-
+        Profiler::begin("color_grading_pass");
         color_grading_pass.draw();
-
+        Profiler::end();
         m_vulkan_rhi->m_vk_cmd_next_subpass(m_vulkan_rhi->m_current_command_buffer, VK_SUBPASS_CONTENTS_INLINE);
 
         if (m_enable_fxaa) fxaa_pass.draw();
@@ -2305,15 +2310,18 @@ namespace Piccolo
                                              clear_attachments,
                                              sizeof(clear_rects) / sizeof(clear_rects[0]),
                                              clear_rects);
-
+        Profiler::begin("drawAxis");
         drawAxis();
-
+        Profiler::end();
+        
+        Profiler::begin("ui draw");
         ui_pass.draw();
+        
 
         m_vulkan_rhi->m_vk_cmd_next_subpass(m_vulkan_rhi->m_current_command_buffer, VK_SUBPASS_CONTENTS_INLINE);
 
         combine_ui_pass.draw();
-
+        Profiler::end();
         m_vulkan_rhi->m_vk_cmd_end_render_pass(m_vulkan_rhi->m_current_command_buffer);
     }
 

--- a/engine/source/runtime/function/render/passes/point_light_pass.cpp
+++ b/engine/source/runtime/function/render/passes/point_light_pass.cpp
@@ -4,6 +4,7 @@
 #include "runtime/function/render/rhi/vulkan/vulkan_util.h"
 
 #include "runtime/function/render/passes/point_light_pass.h"
+#include "runtime/function/utils/profiler.h"
 
 #include <mesh_point_light_shadow_frag.h>
 #include <mesh_point_light_shadow_geom.h>
@@ -502,7 +503,7 @@ namespace Piccolo
         };
 
         std::map<VulkanPBRMaterial*, std::map<VulkanMesh*, std::vector<MeshNode>>> point_lights_mesh_drawcall_batch;
-
+        Profiler::begin("reorganize mesh");
         // reorganize mesh
         for (RenderMeshNode& node : *(m_visiable_nodes.p_point_lights_visible_mesh_nodes))
         {
@@ -522,7 +523,9 @@ namespace Piccolo
 
             mesh_nodes.push_back(temp);
         }
+        Profiler::end();
 
+        Profiler::begin("draw");
         VkRenderPassBeginInfo renderpass_begin_info {};
         renderpass_begin_info.sType             = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
         renderpass_begin_info.renderPass        = m_framebuffer.render_pass;
@@ -739,6 +742,7 @@ namespace Piccolo
         }
 
         m_vulkan_rhi->m_vk_cmd_end_render_pass(m_vulkan_rhi->m_current_command_buffer);
+        Profiler::end();
     }
 
 } // namespace Piccolo

--- a/engine/source/runtime/function/render/render_system.cpp
+++ b/engine/source/runtime/function/render/render_system.cpp
@@ -16,6 +16,7 @@
 #include "runtime/function/render/passes/main_camera_pass.h"
 
 #include "runtime/function/render/rhi/vulkan/vulkan_rhi.h"
+#include "runtime/function/utils/profiler.h"
 
 namespace Piccolo
 {
@@ -91,29 +92,43 @@ namespace Piccolo
     void RenderSystem::tick()
     {
         // process swap data between logic and render contexts
+        Profiler::begin("processSwapData");
         processSwapData();
+        Profiler::end();
 
+        Profiler::begin("prepareContext");
         // prepare render command context
         m_rhi->prepareContext();
+        Profiler::end();
 
+        Profiler::begin("updatePerFrameBuffer");
         // update per-frame buffer
         m_render_resource->updatePerFrameBuffer(m_render_scene, m_render_camera);
+        Profiler::end();
 
+        Profiler::begin("updateVisibleObjects");
         // update per-frame visible objects
         m_render_scene->updateVisibleObjects(std::static_pointer_cast<RenderResource>(m_render_resource),
                                              m_render_camera);
+        Profiler::end();
 
+        Profiler::begin("preparePassData");
         // prepare pipeline's render passes data
         m_render_pipeline->preparePassData(m_render_resource);
+        Profiler::end();
 
         // render one frame
         if (m_render_pipeline_type == RENDER_PIPELINE_TYPE::FORWARD_PIPELINE)
         {
+            Profiler::begin("forwardRender");
             m_render_pipeline->forwardRender(m_rhi, m_render_resource);
+            Profiler::end();
         }
         else if (m_render_pipeline_type == RENDER_PIPELINE_TYPE::DEFERRED_PIPELINE)
         {
+            Profiler::begin("deferredRender");
             m_render_pipeline->deferredRender(m_rhi, m_render_resource);
+            Profiler::end();
         }
         else
         {

--- a/engine/source/runtime/function/utils/profiler.cpp
+++ b/engine/source/runtime/function/utils/profiler.cpp
@@ -1,0 +1,98 @@
+#include "profiler.h"
+#include <stdexcept>
+#include <fstream>
+namespace Piccolo
+{
+    void ChromeProfilingResultOutput::output(const std::list<ProfilingEvent> result) {
+		std::string result_json = "[\n";
+		for (auto& i : result) {
+			result_json += "{\"name\": \"" + i.name + "\"," \
+                + "\"ph\":\"X\",\"id\":\"0\",\"pid\":\"0\",\"tid\":\"" \
+                + std::to_string(i.depth) \
+                + "\",\"ts\":" + std::to_string(i.start_time) \
+                + ",\"dur\":" + std::to_string(i.duration) + "},\n";
+
+		}
+
+		result_json[result_json.size() - 2] = ' ';
+		result_json += "]\n";
+
+		std::ofstream out(file_name);
+		out << result_json;
+	}
+
+    namespace Profiler
+    {
+        uint32_t current_depth = 0;
+		bool in_record = false;
+		std::chrono::steady_clock::time_point start_time_point;
+		std::chrono::steady_clock::time_point current_time_point;
+		uint64_t time_duration_from_start;
+		std::stack<ProfilingEvent> work_stack;
+		std::list<ProfilingEvent> result_list;
+
+		ProfilingEvent current_event;
+        bool enable_profiling;
+        ///////////////
+        void init(bool enable) {
+            enable_profiling = enable;
+            start_time_point = std::chrono::high_resolution_clock::now();
+        }
+
+        void begin(const std::string& name) {
+            if(!enable_profiling) return;
+
+            tickCurrentTimePoint();
+            if (in_record == false) {
+                in_record = true;
+                current_event.name = name;
+                current_event.start_time = time_duration_from_start;
+                current_event.depth = current_depth;
+            }
+            else {
+                work_stack.push(current_event);
+                current_event.name = name;
+                current_event.start_time = time_duration_from_start;
+                current_event.depth = current_depth;
+            }
+            current_depth++;
+        }
+
+        void end() {
+            if(!enable_profiling) return;
+
+            tickCurrentTimePoint();
+            if (in_record == false) {
+                throw std::runtime_error("Did not start any records");
+            }
+            current_event.duration = time_duration_from_start - current_event.start_time;
+            result_list.push_back(current_event);
+
+            if (!work_stack.empty()) {
+                current_event = work_stack.top();
+                work_stack.pop();
+            }
+            else {
+                in_record = false;
+            }
+            current_depth--;
+        }
+
+        void tickCurrentTimePoint() {
+            current_time_point = std::chrono::high_resolution_clock::now();
+            time_duration_from_start = std::chrono::duration_cast<std::chrono::microseconds>(current_time_point - start_time_point).count();
+        }
+
+        void output(IProfilingResultOutput* output) {
+            if(!enable_profiling) return;
+            
+            if (in_record) {
+                throw std::runtime_error(" ");
+            }
+            output->output(result_list);
+        }
+
+    }
+
+
+}

--- a/engine/source/runtime/function/utils/profiler.h
+++ b/engine/source/runtime/function/utils/profiler.h
@@ -1,0 +1,47 @@
+#include <list>
+#include <stack>
+#include <string>
+#include <chrono>
+
+namespace Piccolo
+{
+    struct ProfilingEvent 
+    {
+		std::string name;
+		uint64_t start_time;
+		uint64_t duration;
+		uint32_t depth;
+	};
+
+	class IProfilingResultOutput 
+    {
+	public:
+		virtual ~IProfilingResultOutput() {}
+		virtual void output(const std::list<ProfilingEvent> result) = 0;
+	};
+
+	class ChromeProfilingResultOutput : public IProfilingResultOutput 
+    {
+	public:
+		ChromeProfilingResultOutput(std::string file) : file_name(file) {}
+		virtual ~ChromeProfilingResultOutput() {}
+		virtual void output(const std::list<ProfilingEvent> result) override;
+	private:
+		std::string file_name;
+	};
+
+	namespace Profiler 
+    {
+	
+		
+		void init(bool enable = true);
+
+		void begin(const std::string& name);
+		void end();
+		void output(IProfilingResultOutput* output);
+	
+
+    /////////
+		void tickCurrentTimePoint();
+	}
+}


### PR DESCRIPTION
添加性能分析工具，在PiccoloEngine::initialize()中初始化，可选择传入false将其关闭，将待分析的函数使用Profiler::begin和Profiler::end包围，正常运行引擎，运行完毕后生成profiling.json文件，在edge(或chrome)浏览器中打开 edge://tracing 将该文件拖入其中以查看性能分析结果。