### PR TITLE
fix first person camera lookatMat

### DIFF
--- a/engine/source/runtime/function/framework/component/camera/camera_component.cpp
+++ b/engine/source/runtime/function/framework/component/camera/camera_component.cpp
@@ -92,7 +92,7 @@ namespace Piccolo
         m_left   = q_yaw * q_pitch * m_left;
         m_up     = m_foward.crossProduct(m_left);
 
-        Matrix4x4 desired_mat = Math::makeLookAtMatrix(eye_pos, m_foward, m_up);
+        Matrix4x4 desired_mat = Math::makeLookAtMatrix(eye_pos, eye_pos + m_foward, m_up);
 
         RenderSwapContext& swap_context = g_runtime_global_context.m_render_system->getSwapContext();
         CameraSwapData     camera_swap_data;


### PR DESCRIPTION
When I try to add a function about switch to first-person-view，I found the lookAt Matrix use wrong parameter. So I fixed it. 

Besides I also have a try the first person vertical offset and found its position may not reasonable, which is 0.6. Thus the first-person-view was build on the legs of the character. 

What's more,  The engine uses rotation dirty flag to update character orientation. In the third-person-view it works well and save resource but it seems a little strange in the first-person-view.