### PR TITLE
feature: Add checkbox for bool field in editor ui

### DIFF
--- a/engine/source/editor/source/editor_ui.cpp
+++ b/engine/source/editor/source/editor_ui.cpp
@@ -118,6 +118,24 @@ namespace Piccolo
                 g_editor_global_context.m_scene_manager->drawSelectedEntityAxis();
             }
         };
+        m_editor_ui_creator["bool"] = [this](const std::string& name, void* value_ptr)  -> void {
+            if(g_node_depth == -1)
+            {
+                std::string label = "##" + name;
+                ImGui::Text("%s", name.c_str());
+                ImGui::SameLine();
+                ImGui::Checkbox(label.c_str(), static_cast<bool*>(value_ptr));
+            }
+            else
+            {
+                if(g_editor_node_state_array[g_node_depth].second)
+                {
+                    std::string full_label = "##" + getLeafUINodeParentLabel() + name;
+                    ImGui::Text("%s", name.c_str());
+                    ImGui::Checkbox(full_label.c_str(), static_cast<bool*>(value_ptr));
+                }
+            }
+        };
         m_editor_ui_creator["int"] = [this](const std::string& name, void* value_ptr) -> void {
             if (g_node_depth == -1)
             {


### PR DESCRIPTION
While adding bool to a reflectable field, I discover that the editor UI won't show a bool field, so add a check box for bool field in editor UI