### PR TITLE
修复直接光照下阴影显示不全

### DIFF
--- a/engine/source/runtime/core/math/math.cpp
+++ b/engine/source/runtime/core/math/math.cpp
@@ -163,7 +163,7 @@ namespace Piccolo
         float C  = -(right + left) * inv_width;
         float D  = -(top + bottom) * inv_height;
         float q  = -2 * inv_distance;
-        float qn = qn = -(zfar + znear) * inv_distance;
+        float qn = -(zfar + znear) * inv_distance;
 
         // NB: This creates 'uniform' orthographic projection matrix,
         // which depth range [-1,1], right-handed rules
@@ -179,6 +179,47 @@ namespace Piccolo
         // D = - (top + bottom) / (top - bottom)
         // q = - 2 / (far - near)
         // qn = - (far + near) / (far - near)
+
+        Matrix4x4 proj_matrix = Matrix4x4::ZERO;
+        proj_matrix[0][0]     = A;
+        proj_matrix[0][3]     = C;
+        proj_matrix[1][1]     = B;
+        proj_matrix[1][3]     = D;
+        proj_matrix[2][2]     = q;
+        proj_matrix[2][3]     = qn;
+        proj_matrix[3][3]     = 1;
+
+        return proj_matrix;
+    }
+
+    Matrix4x4
+    Math::makeOrthographicProjectionMatrix01(float left, float right, float bottom, float top, float znear, float zfar)
+    {
+        float inv_width    = 1.0f / (right - left);
+        float inv_height   = 1.0f / (top - bottom);
+        float inv_distance = 1.0f / (zfar - znear);
+
+        float A  = 2 * inv_width;
+        float B  = 2 * inv_height;
+        float C  = -(right + left) * inv_width;
+        float D  = -(top + bottom) * inv_height;
+        float q  = -1 * inv_distance;
+        float qn = -znear * inv_distance;
+
+        // NB: This creates 'uniform' orthographic projection matrix,
+        // which depth range [-1,1], right-handed rules
+        //
+        // [ A   0   0   C  ]
+        // [ 0   B   0   D  ]
+        // [ 0   0   q   qn ]
+        // [ 0   0   0   1  ]
+        //
+        // A = 2 * / (right - left)
+        // B = 2 * / (top - bottom)
+        // C = - (right + left) / (right - left)
+        // D = - (top + bottom) / (top - bottom)
+        // q = - 1 / (far - near)
+        // qn = - near / (far - near)
 
         Matrix4x4 proj_matrix = Matrix4x4::ZERO;
         proj_matrix[0][0]     = A;

--- a/engine/source/runtime/core/math/math.h
+++ b/engine/source/runtime/core/math/math.h
@@ -265,6 +265,9 @@ namespace Piccolo
 
         static Matrix4x4
         makeOrthographicProjectionMatrix(float left, float right, float bottom, float top, float znear, float zfar);
+        
+        static Matrix4x4
+        makeOrthographicProjectionMatrix01(float left, float right, float bottom, float top, float znear, float zfar);
     };
 
     // these functions could not be defined within the class definition of class

--- a/engine/source/runtime/function/render/passes/directional_light_pass.cpp
+++ b/engine/source/runtime/function/render/passes/directional_light_pass.cpp
@@ -527,7 +527,7 @@ namespace Piccolo
         }
 
         // Mesh
-        if (m_vulkan_rhi->isPointLightShadowEnabled())
+        // if (m_vulkan_rhi->isPointLightShadowEnabled())
         {
             if (m_vulkan_rhi->isDebugLabelEnabled())
             {

--- a/engine/source/runtime/function/render/render_helper.cpp
+++ b/engine/source/runtime/function/render/render_helper.cpp
@@ -334,7 +334,7 @@ namespace Piccolo
 
             BoundingBox frustum_bounding_box_light_view = BoundingBoxTransform(frustum_bounding_box, light_view);
             BoundingBox scene_bounding_box_light_view   = BoundingBoxTransform(scene_bounding_box, light_view);
-            light_proj = Math::makeOrthographicProjectionMatrix(
+            light_proj = Math::makeOrthographicProjectionMatrix01(
                 std::max(frustum_bounding_box_light_view.min_bound.x, scene_bounding_box_light_view.min_bound.x),
                 std::min(frustum_bounding_box_light_view.max_bound.x, scene_bounding_box_light_view.max_bound.x),
                 std::max(frustum_bounding_box_light_view.min_bound.y, scene_bounding_box_light_view.min_bound.y),


### PR DESCRIPTION
阴影的正交矩阵计算的Z值范围是[-1,1], 改成 [0,1]