### PR TITLE
移除了onCursorPos函数中对m_mouse_x和 m_mouse_y的判断

### DIFF
--- a/engine/source/editor/source/editor_input_manager.cpp
+++ b/engine/source/editor/source/editor_input_manager.cpp
@@ -192,38 +192,35 @@ namespace Piccolo
 
         float angularVelocity =
             180.0f / Math::max(m_engine_window_size.x, m_engine_window_size.y); // 180 degrees while moving full screen
-        if (m_mouse_x >= 0.0f && m_mouse_y >= 0.0f)
+        if (g_editor_global_context.m_window_system->isMouseButtonDown(GLFW_MOUSE_BUTTON_RIGHT))
         {
-            if (g_editor_global_context.m_window_system->isMouseButtonDown(GLFW_MOUSE_BUTTON_RIGHT))
-            {
-                glfwSetInputMode(
-                    g_editor_global_context.m_window_system->getWindow(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-                g_editor_global_context.m_scene_manager->getEditorCamera()->rotate(
-                    Vector2(ypos - m_mouse_y, xpos - m_mouse_x) * angularVelocity);
-            }
-            else if (g_editor_global_context.m_window_system->isMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT))
-            {
-                g_editor_global_context.m_scene_manager->moveEntity(
-                    xpos,
-                    ypos,
-                    m_mouse_x,
-                    m_mouse_y,
-                    m_engine_window_pos,
-                    m_engine_window_size,
-                    m_cursor_on_axis,
-                    g_editor_global_context.m_scene_manager->getSelectedObjectMatrix());
-                glfwSetInputMode(g_editor_global_context.m_window_system->getWindow(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
-            }
-            else
-            {
-                glfwSetInputMode(g_editor_global_context.m_window_system->getWindow(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+            glfwSetInputMode(
+                g_editor_global_context.m_window_system->getWindow(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+            g_editor_global_context.m_scene_manager->getEditorCamera()->rotate(
+                Vector2(ypos - m_mouse_y, xpos - m_mouse_x) * angularVelocity);
+        }
+        else if (g_editor_global_context.m_window_system->isMouseButtonDown(GLFW_MOUSE_BUTTON_LEFT))
+        {
+            g_editor_global_context.m_scene_manager->moveEntity(
+                xpos,
+                ypos,
+                m_mouse_x,
+                m_mouse_y,
+                m_engine_window_pos,
+                m_engine_window_size,
+                m_cursor_on_axis,
+                g_editor_global_context.m_scene_manager->getSelectedObjectMatrix());
+            glfwSetInputMode(g_editor_global_context.m_window_system->getWindow(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+        }
+        else
+        {
+            glfwSetInputMode(g_editor_global_context.m_window_system->getWindow(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 
-                if (isCursorInRect(m_engine_window_pos, m_engine_window_size))
-                {
-                    Vector2 cursor_uv = Vector2((m_mouse_x - m_engine_window_pos.x) / m_engine_window_size.x,
-                                                (m_mouse_y - m_engine_window_pos.y) / m_engine_window_size.y);
-                    updateCursorOnAxis(cursor_uv);
-                }
+            if (isCursorInRect(m_engine_window_pos, m_engine_window_size))
+            {
+                Vector2 cursor_uv = Vector2((m_mouse_x - m_engine_window_pos.x) / m_engine_window_size.x,
+                                            (m_mouse_y - m_engine_window_pos.y) / m_engine_window_size.y);
+                updateCursorOnAxis(cursor_uv);
             }
         }
         m_mouse_x = xpos;


### PR DESCRIPTION
这里if (m_mouse_x >= 0.0f && m_mouse_y >= 0.0f)的限制会导致在editor_mode下使用右键旋转相机时，鼠标向左（或向上）移动一定距离后就无法继续向左（或向上）旋转相机了。