### PR TITLE
fix access modifiers, change repeatd protected to private.

### DIFF
--- a/engine/source/runtime/engine.h
+++ b/engine/source/runtime/engine.h
@@ -41,7 +41,7 @@ namespace Piccolo
          */
         float calculateDeltaTime();
 
-    protected:
+    private:
         bool m_is_quit {false};
 
         std::chrono::steady_clock::time_point m_last_tick_time_point {std::chrono::steady_clock::now()};


### PR DESCRIPTION
class PiccoloEngine 内第二个protected看起来应该是private，下方的变量都是类内部使用。