### PR TITLE
Vulkan 断言条件修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,42 @@
 To build Piccolo, you must first install the following tools.
 
 ### Windows 10/11
-
 - Visual Studio 2019 (or more recent)
 - CMake 3.19 (or more recent)
 - Git 2.1 (or more recent)
 
 ### macOS >= 10.15 (x86_64)
-
 - Xcode 12.3 (or more recent)
 - CMake 3.19 (or more recent)
 - Git 2.1 (or more recent)
 
 ### Ubuntu 20.04
-
-- apt install the following packages
-
-  ```
-  libxrandr-dev libxrender-dev libxinerama-dev libxcursor-dev libxi-dev libglvnd-dev libvulkan-dev cmake clang libc++-dev libglew-dev libglfw3-dev vulkan-validationlayers mesa-vulkan-drivers
-  ```
-
+ - apt install the following packages
+```
+sudo apt install libxrandr-dev
+sudo apt install libxrender-dev
+sudo apt install libxinerama-dev
+sudo apt install libxcursor-dev
+sudo apt install libxi-dev
+sudo apt install libglvnd-dev
+sudo apt install libvulkan-dev
+sudo apt install cmake
+sudo apt install clang
+sudo apt install libc++-dev
+sudo apt install libglew-dev
+sudo apt install libglfw3-dev
+sudo apt install vulkan-validationlayers
+sudo apt install mesa-vulkan-drivers
+```
 - [NVIDIA driver](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#runfile) (The AMD and Intel driver is open-source, and thus is installed automatically by mesa-vulkan-drivers)
 
 ## Build Piccolo
 
 ### Build on Windows
-
-You may execute the `build_windows.bat`. This batch file will generate the projects, and build the **Release** config of **Piccolo Engine** automatically. After successful build, you can find the PiccoloEditor.exe at the **bin** directory.
+You may execute the **build_windows.bat**. This batch file will generate the projects, and build the **Release** config of **Piccolo Engine** automatically. After successful build, you can find the PiccoloEditor.exe at the **bin** directory.
 
 Or you can use the following command to generate the **Visual Studio** project firstly, then open the solution in the build directory and build it manually.
-
-```sh
+```
 cmake -S . -B build
 ```
 
@@ -61,30 +67,25 @@ cmake -S . -B build
 To compile Piccolo, you must have the most recent version of Xcode installed.
 Then run 'cmake' from the project's root directory, to generate a project of Xcode.
 
-```sh
+```
 cmake -S . -B build -G "Xcode"
 ```
-
 and you can build the project with
-
-```sh
+```
 cmake --build build --config Release
 ```
 
-Or you can execute the `build_macos.sh` to build the binaries.
+Or you can execute the **build_macos.sh** to build the binaries.
 
 ### Build on Ubuntu 20.04
-
-You can execute the `build_linux.sh` to build the binaries.
+You can execute the **build_linux.sh** to build the binaries.
 
 ## Documentation
-
 For documentation, please refer to the Wiki section.
 
 ## Extra
 
 ### Vulkan Validation Layer: Validation Error
-
 We have noticed some developers on Windows encounted PiccoloEditor.exe could run normally but reported an exception Vulkan Validation Layer: Validation Error
 when debugging. You can solve this problem by installing Vulkan SDK (official newest version will do).
 
@@ -101,7 +102,6 @@ copy compile_db_temp\compile_commands.json .
 ```
 
 ### Using Physics Debug Renderer
-
 Currently Physics Debug Renderer is only available on Windows. You can use the following command to generate the solution with the debugger project.
 
 ``` powershell
@@ -109,6 +109,5 @@ cmake -S . -B build -DENABLE_PHYSICS_DEBUG_RENDERER=ON
 ```
 
 Note:
-
 1. Please clean the build directory before regenerating the solution. We've encountered building problems in regenerating directly with previous CMakeCache.
 2. Physics Debug Renderer will run when you start PiccoloEditor. We've synced the camera position between both scenes. But the initial camera mode in Physics Debug Renderer is wrong. Scrolling down the mouse wheel once will change the camera of Physics Debug Renderer to the correct mode.

--- a/README.md
+++ b/README.md
@@ -21,42 +21,36 @@
 To build Piccolo, you must first install the following tools.
 
 ### Windows 10/11
+
 - Visual Studio 2019 (or more recent)
 - CMake 3.19 (or more recent)
 - Git 2.1 (or more recent)
 
 ### macOS >= 10.15 (x86_64)
+
 - Xcode 12.3 (or more recent)
 - CMake 3.19 (or more recent)
 - Git 2.1 (or more recent)
 
 ### Ubuntu 20.04
- - apt install the following packages
-```
-sudo apt install libxrandr-dev
-sudo apt install libxrender-dev
-sudo apt install libxinerama-dev
-sudo apt install libxcursor-dev
-sudo apt install libxi-dev
-sudo apt install libglvnd-dev
-sudo apt install libvulkan-dev
-sudo apt install cmake
-sudo apt install clang
-sudo apt install libc++-dev
-sudo apt install libglew-dev
-sudo apt install libglfw3-dev
-sudo apt install vulkan-validationlayers
-sudo apt install mesa-vulkan-drivers
-```
+
+- apt install the following packages
+
+  ```
+  libxrandr-dev libxrender-dev libxinerama-dev libxcursor-dev libxi-dev libglvnd-dev libvulkan-dev cmake clang libc++-dev libglew-dev libglfw3-dev vulkan-validationlayers mesa-vulkan-drivers
+  ```
+
 - [NVIDIA driver](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#runfile) (The AMD and Intel driver is open-source, and thus is installed automatically by mesa-vulkan-drivers)
 
 ## Build Piccolo
 
 ### Build on Windows
-You may execute the **build_windows.bat**. This batch file will generate the projects, and build the **Release** config of **Piccolo Engine** automatically. After successful build, you can find the PiccoloEditor.exe at the **bin** directory.
+
+You may execute the `build_windows.bat`. This batch file will generate the projects, and build the **Release** config of **Piccolo Engine** automatically. After successful build, you can find the PiccoloEditor.exe at the **bin** directory.
 
 Or you can use the following command to generate the **Visual Studio** project firstly, then open the solution in the build directory and build it manually.
-```
+
+```sh
 cmake -S . -B build
 ```
 
@@ -67,25 +61,30 @@ cmake -S . -B build
 To compile Piccolo, you must have the most recent version of Xcode installed.
 Then run 'cmake' from the project's root directory, to generate a project of Xcode.
 
-```
+```sh
 cmake -S . -B build -G "Xcode"
 ```
+
 and you can build the project with
-```
+
+```sh
 cmake --build build --config Release
 ```
 
-Or you can execute the **build_macos.sh** to build the binaries.
+Or you can execute the `build_macos.sh` to build the binaries.
 
 ### Build on Ubuntu 20.04
-You can execute the **build_linux.sh** to build the binaries.
+
+You can execute the `build_linux.sh` to build the binaries.
 
 ## Documentation
+
 For documentation, please refer to the Wiki section.
 
 ## Extra
 
 ### Vulkan Validation Layer: Validation Error
+
 We have noticed some developers on Windows encounted PiccoloEditor.exe could run normally but reported an exception Vulkan Validation Layer: Validation Error
 when debugging. You can solve this problem by installing Vulkan SDK (official newest version will do).
 
@@ -102,6 +101,7 @@ copy compile_db_temp\compile_commands.json .
 ```
 
 ### Using Physics Debug Renderer
+
 Currently Physics Debug Renderer is only available on Windows. You can use the following command to generate the solution with the debugger project.
 
 ``` powershell
@@ -109,5 +109,6 @@ cmake -S . -B build -DENABLE_PHYSICS_DEBUG_RENDERER=ON
 ```
 
 Note:
+
 1. Please clean the build directory before regenerating the solution. We've encountered building problems in regenerating directly with previous CMakeCache.
 2. Physics Debug Renderer will run when you start PiccoloEditor. We've synced the camera position between both scenes. But the initial camera mode in Physics Debug Renderer is wrong. Scrolling down the mouse wheel once will change the camera of Physics Debug Renderer to the correct mode.

--- a/engine/source/runtime/function/render/passes/directional_light_pass.cpp
+++ b/engine/source/runtime/function/render/passes/directional_light_pass.cpp
@@ -555,7 +555,7 @@ namespace Piccolo
                         RHIBuffer*     vertex_buffers[] = {mesh->mesh_vertex_position_buffer};
                         RHIDeviceSize offsets[]        = {0};
                         m_rhi->cmdBindVertexBuffersPFN(m_rhi->getCurrentCommandBuffer(), 0, 1, vertex_buffers, offsets);
-                        m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(), mesh->mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT16);
+                        m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(), mesh->mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT32);
 
                         uint32_t drawcall_max_instance_count =
                             (sizeof(MeshDirectionalLightShadowPerdrawcallStorageBufferObject::mesh_instances) /

--- a/engine/source/runtime/function/render/passes/main_camera_pass.cpp
+++ b/engine/source/runtime/function/render/passes/main_camera_pass.cpp
@@ -2202,7 +2202,8 @@ namespace Piccolo
                                                    (sizeof(vertex_buffers) / sizeof(vertex_buffers[0])),
                                                    vertex_buffers,
                                                    offsets);
-                    m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(), mesh.mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT16);
+                    m_rhi->cmdBindIndexBufferPFN(
+                        m_rhi->getCurrentCommandBuffer(), mesh.mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT32);
 
                     uint32_t drawcall_max_instance_count =
                         (sizeof(MeshPerdrawcallStorageBufferObject::mesh_instances) /
@@ -2474,7 +2475,7 @@ namespace Piccolo
                                                    (sizeof(vertex_buffers) / sizeof(vertex_buffers[0])),
                                                    vertex_buffers,
                                                    offsets);
-                    m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(), mesh.mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT16);
+                    m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(), mesh.mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT32);
 
                     uint32_t drawcall_max_instance_count =
                         (sizeof(MeshPerdrawcallStorageBufferObject::mesh_instances) /
@@ -2697,7 +2698,7 @@ namespace Piccolo
         m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(),
                                      m_visiable_nodes.p_axis_node->ref_mesh->mesh_index_buffer,
                                      0,
-                                     RHI_INDEX_TYPE_UINT16);
+                                     RHI_INDEX_TYPE_UINT32);
         (*reinterpret_cast<AxisStorageBufferObject*>(reinterpret_cast<uintptr_t>(
             m_global_render_resource->_storage_buffer._axis_inefficient_storage_buffer_memory_pointer))) =
             m_axis_storage_buffer_object;

--- a/engine/source/runtime/function/render/passes/pick_pass.cpp
+++ b/engine/source/runtime/function/render/passes/pick_pass.cpp
@@ -577,7 +577,7 @@ namespace Piccolo
                     m_rhi->cmdBindIndexBufferPFN(m_rhi->getCurrentCommandBuffer(),
                                                  mesh.mesh_index_buffer,
                                                  0,
-                                                 RHI_INDEX_TYPE_UINT16);
+                                                 RHI_INDEX_TYPE_UINT32);
 
                     uint32_t drawcall_max_instance_count =
                         (sizeof(MeshInefficientPickPerdrawcallStorageBufferObject::model_matrices) /

--- a/engine/source/runtime/function/render/passes/point_light_pass.cpp
+++ b/engine/source/runtime/function/render/passes/point_light_pass.cpp
@@ -568,7 +568,7 @@ namespace Piccolo
                         m_rhi->cmdBindVertexBuffersPFN(
                             m_rhi->getCurrentCommandBuffer(), 0, 1, vertex_buffers, offsets);
                         m_rhi->cmdBindIndexBufferPFN(
-                            m_rhi->getCurrentCommandBuffer(), mesh.mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT16);
+                            m_rhi->getCurrentCommandBuffer(), mesh.mesh_index_buffer, 0, RHI_INDEX_TYPE_UINT32);
 
                         uint32_t drawcall_max_instance_count =
                             (sizeof(MeshPointLightShadowPerdrawcallStorageBufferObject::mesh_instances) /

--- a/engine/source/runtime/function/render/render_resource_base.cpp
+++ b/engine/source/runtime/function/render/render_resource_base.cpp
@@ -327,7 +327,7 @@ namespace Piccolo
         mesh_data.m_vertex_buffer = std::make_shared<BufferData>(mesh_vertices.size() * stride);
         mesh_data.m_index_buffer  = std::make_shared<BufferData>(mesh_vertices.size() * sizeof(uint16_t));
 
-        assert(mesh_vertices.size() <= std::numeric_limits<uint16_t>::max()); // take care of the index range, should be
+        assert(mesh_vertices.size() <= std::numeric_limits<uint32_t>::max()); // take care of the index range, should be
                                                                               // consistent with the index range used by
                                                                               // vulkan
 

--- a/engine/source/runtime/function/render/render_resource_base.cpp
+++ b/engine/source/runtime/function/render/render_resource_base.cpp
@@ -70,11 +70,10 @@ namespace Piccolo
         if (!texture->m_pixels)
             return nullptr;
 
-        texture->m_width        = iw;
-        texture->m_height       = ih;
-        texture->m_format       = (is_srgb) ? RHIFormat::RHI_FORMAT_R8G8B8A8_SRGB :
-                                              RHIFormat::RHI_FORMAT_R8G8B8A8_UNORM;
-        texture->m_depth        = 1;
+        texture->m_width  = iw;
+        texture->m_height = ih;
+        texture->m_format = (is_srgb) ? RHIFormat::RHI_FORMAT_R8G8B8A8_SRGB : RHIFormat::RHI_FORMAT_R8G8B8A8_UNORM;
+        texture->m_depth  = 1;
         texture->m_array_layers = 1;
         texture->m_mip_levels   = 1;
         texture->m_type         = PICCOLO_IMAGE_TYPE::PICCOLO_IMAGE_TYPE_2D;
@@ -121,12 +120,12 @@ namespace Piccolo
             }
 
             // index buffer
-            size_t index_size                     = bind_data->index_buffer.size() * sizeof(uint16_t);
+            size_t index_size                     = bind_data->index_buffer.size() * sizeof(uint32_t);
             ret.m_static_mesh_data.m_index_buffer = std::make_shared<BufferData>(index_size);
-            uint16_t* index                       = (uint16_t*)ret.m_static_mesh_data.m_index_buffer->m_data;
+            uint32_t* index                       = (uint32_t*)ret.m_static_mesh_data.m_index_buffer->m_data;
             for (size_t i = 0; i < bind_data->index_buffer.size(); i++)
             {
-                index[i] = static_cast<uint16_t>(bind_data->index_buffer[i]);
+                index[i] = static_cast<uint32_t>(bind_data->index_buffer[i]);
             }
 
             // skeleton binding buffer
@@ -325,17 +324,17 @@ namespace Piccolo
 
         uint32_t stride           = sizeof(MeshVertexDataDefinition);
         mesh_data.m_vertex_buffer = std::make_shared<BufferData>(mesh_vertices.size() * stride);
-        mesh_data.m_index_buffer  = std::make_shared<BufferData>(mesh_vertices.size() * sizeof(uint16_t));
+        mesh_data.m_index_buffer  = std::make_shared<BufferData>(mesh_vertices.size() * sizeof(uint32_t));
 
         assert(mesh_vertices.size() <= std::numeric_limits<uint32_t>::max()); // take care of the index range, should be
                                                                               // consistent with the index range used by
                                                                               // vulkan
 
-        uint16_t* indices = (uint16_t*)mesh_data.m_index_buffer->m_data;
+        uint32_t* indices = (uint32_t*)mesh_data.m_index_buffer->m_data;
         for (size_t i = 0; i < mesh_vertices.size(); i++)
         {
             ((MeshVertexDataDefinition*)(mesh_data.m_vertex_buffer->m_data))[i] = mesh_vertices[i];
-            indices[i]                                                          = static_cast<uint16_t>(i);
+            indices[i]                                                          = static_cast<uint32_t>(i);
         }
 
         return mesh_data;


### PR DESCRIPTION
Vulkan 的顶点缓冲区至少支持 `std::numeric_limits<uint32_t>::max()` 个顶点[^1], 为确保顶点数较多的模型能够成功加载, 对断言进行了修正.  

[^1]: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdDraw.html