### PR TITLE
fix gpu particle level reload logic

### DIFF
--- a/engine/source/runtime/function/framework/level/level.cpp
+++ b/engine/source/runtime/function/framework/level/level.cpp
@@ -67,6 +67,7 @@ namespace Piccolo
 
         ASSERT(g_runtime_global_context.m_physics_manager);
         m_physics_scene = g_runtime_global_context.m_physics_manager->createPhysicsScene(level_res.m_gravity);
+        ParticleEmitterIDAllocator::reset();
 
         for (const ObjectInstanceRes& object_instance_res : level_res.m_objects)
         {

--- a/engine/source/runtime/function/particle/emitter_id_allocator.cpp
+++ b/engine/source/runtime/function/particle/emitter_id_allocator.cpp
@@ -18,4 +18,8 @@ namespace Piccolo
         return new_emitter_ret;
     }
 
+    void ParticleEmitterIDAllocator::reset()
+    {
+        m_next_id.store(0);
+    }
 } // namespace Piccolo

--- a/engine/source/runtime/function/particle/emitter_id_allocator.h
+++ b/engine/source/runtime/function/particle/emitter_id_allocator.h
@@ -13,6 +13,7 @@ namespace Piccolo
     {
     public:
         static ParticleEmitterID alloc();
+        static void reset();
 
     private:
         static std::atomic<ParticleEmitterID> m_next_id;

--- a/engine/source/runtime/function/render/passes/particle_pass.cpp
+++ b/engine/source/runtime/function/render/passes/particle_pass.cpp
@@ -31,7 +31,6 @@ namespace Piccolo
         rhi->freeMemory(m_particle_component_res_memory);
         rhi->freeMemory(m_position_render_memory);
 
-        rhi->destroyBuffer(m_particle_storage_buffer);
         rhi->destroyBuffer(m_position_render_buffer);
         rhi->destroyBuffer(m_position_device_buffer);
         rhi->destroyBuffer(m_position_host_buffer);

--- a/engine/source/runtime/function/render/passes/particle_pass.h
+++ b/engine/source/runtime/function/render/passes/particle_pass.h
@@ -15,7 +15,6 @@ namespace Piccolo
     class ParticleEmitterBufferBatch
     {
     public:
-        RHIBuffer* m_particle_storage_buffer = nullptr;
         RHIBuffer* m_position_render_buffer = nullptr;
         RHIBuffer* m_position_device_buffer = nullptr;
         RHIBuffer* m_position_host_buffer = nullptr;

--- a/engine/source/runtime/function/render/render_system.cpp
+++ b/engine/source/runtime/function/render/render_system.cpp
@@ -235,10 +235,6 @@ namespace Piccolo
     void RenderSystem::clearForLevelReloading()
     {
         m_render_scene->clearForLevelReloading();
-
-        ParticleSubmitRequest request;
-
-        m_swap_context.getLogicSwapData().m_particle_submit_request = request;
     }
 
     void RenderSystem::setRenderPipelineType(RENDER_PIPELINE_TYPE pipeline_type)


### PR DESCRIPTION
修复关卡重新加载导致的闪退。
1. 删除未使用的指针，会导致销毁时崩溃
2. 关卡重新时重置 particle id 分配器计数