### PR TITLE
Fix JoltPhysics compile error on later clang and Xcode

### DIFF
--- a/build_macos.sh
+++ b/build_macos.sh
@@ -2,9 +2,9 @@
 
 if test \( $# -ne 1 \);
 then
-    echo "Usage: build.sh arch config"
+    echo "Usage: ./build_macos.sh config"
     echo ""
-    echo "Configs:"
+    echo "config:"
     echo "  debug   -   build with the debug configuration"
     echo "  release -   build with the release configuration"
     echo ""

--- a/engine/3rdparty/CMakeLists.txt
+++ b/engine/3rdparty/CMakeLists.txt
@@ -50,6 +50,14 @@ if(NOT TARGET Jolt)
 
     add_subdirectory(JoltPhysics/Build)
 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("-Wno-unqualified-std-cast-call" COMPILER_CHECK_UNQUALIFIED)
+        if(COMPILER_CHECK_UNQUALIFIED)
+            target_compile_options(Jolt PRIVATE "-Wno-unqualified-std-cast-call")
+        endif()
+    endif()
+
     if(ENABLE_PHYSICS_DEBUG_RENDERER)
         set_target_properties(Jolt TestFramework
             PROPERTIES 


### PR DESCRIPTION
新版本的Clang引入了对未限定的move()等操作的检查，导致JoltPhysics库编译产生大量错误失败。见：<https://reviews.llvm.org/D119670>
当前版本的JoltPhysics使用了大量using namespace std;，在不修改JoltPhysics源代码的情况下，在CMake引入依赖时增加`-Wno-unqualified-std-cast-call`编译选项关闭告警对代码产生的破坏性较小。