### PR TITLE
Revert "编辑器模式下物体缩放轴的vertex_data_size计算中多加了8，有一个多余的白色方块"

### DIFF
--- a/engine/source/editor/source/axis.cpp
+++ b/engine/source/editor/source/axis.cpp
@@ -307,7 +307,7 @@ namespace Piccolo
         uint32_t stride = sizeof(MeshVertexDataDefinition);
 
         // vertex
-        size_t vertex_data_size = ((2 * segments + 8) * 3) * stride;
+        size_t vertex_data_size = ((2 * segments + 8) * 3 + 8) * stride;
         m_mesh_data.m_static_mesh_data.m_vertex_buffer = std::make_shared<BufferData>(vertex_data_size);
         uint8_t* vertex_data = static_cast<uint8_t*>(m_mesh_data.m_static_mesh_data.m_vertex_buffer->m_data);
 


### PR DESCRIPTION
This reverts commit 89f1dddc105c0cbe7c33313a4cfe809d36f08947.

这次提交导致了崩溃：https://github.com/BoomingTech/Piccolo/commit/89f1dddc105c0cbe7c33313a4cfe809d36f08947

为了避免别的同学遇到，先revert掉，原问题需再分析