### PR TITLE
Fix parser_header.h multi format errors

### DIFF
--- a/engine/source/editor/CMakeLists.txt
+++ b/engine/source/editor/CMakeLists.txt
@@ -45,4 +45,4 @@ add_custom_command(TARGET ${TARGET_NAME} ${POST_BUILD_COMMANDS})
 
 #precompile
 #set global vari used by precompile
-set(PICCOLO_EDITOR_HEADS “${EDITOR_HEADERS}” PARENT_SCOPE)
+set(PICCOLO_EDITOR_HEADS "${EDITOR_HEADERS}" PARENT_SCOPE)

--- a/engine/source/meta_parser/parser/parser/parser.cpp
+++ b/engine/source/meta_parser/parser/parser/parser.cpp
@@ -129,7 +129,11 @@ bool MetaParser::parseProject()
     {
         std::string temp_string(include_item);
         Utils::replace(temp_string, '\\', '/');
-        include_file << "#include  \"" << temp_string << "\"" << std::endl;
+        for(auto part_string: Utils::split(temp_string, ","))
+        {
+            part_string.erase(std::remove(part_string.begin(), part_string.end(), '\n'));
+            include_file << "#include  \"" << part_string << "\"" << std::endl;
+        }
     }
 
     include_file << "#endif" << std::endl;


### PR DESCRIPTION
- Fix mistaken chinese quote in Editor CmakeLists.exe , which makes trouble in parser_header.h 
- Deal the ',' in precompile.json
- Deal the last ENDL of precompile.json(while result wrong line of include)

Now the parser_header.h looks perfectly beautiful.