### PR TITLE
fix: build error in archlinux

### DIFF
--- a/engine/3rdparty/JoltPhysics/Jolt/Core/Core.h
+++ b/engine/3rdparty/JoltPhysics/Jolt/Core/Core.h
@@ -164,12 +164,12 @@
 // OS-specific includes
 #if defined(JPH_PLATFORM_WINDOWS)
 	#define JPH_BREAKPOINT		__debugbreak()
-#elif defined(JPH_PLATFORM_BLUE) 
+#elif defined(JPH_PLATFORM_BLUE)
 	// Configuration for a popular game console.
-	// This file is not distributed because it would violate an NDA. 
-	// Creating one should only be a couple of minutes of work if you have the documentation for the platform 
+	// This file is not distributed because it would violate an NDA.
+	// Creating one should only be a couple of minutes of work if you have the documentation for the platform
 	// (you only need to define JPH_BREAKPOINT, JPH_PLATFORM_BLUE_GET_TICKS and JPH_PLATFORM_BLUE_GET_TICK_FREQUENCY and include the right header).
-	#include <Jolt/Core/PlatformBlue.h> 
+	#include <Jolt/Core/PlatformBlue.h>
 #elif defined(JPH_PLATFORM_LINUX) || defined(JPH_PLATFORM_ANDROID) || defined(JPH_PLATFORM_MACOS) || defined(JPH_PLATFORM_IOS)
 	#include <float.h>
 	#include <limits.h>
@@ -215,6 +215,7 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <algorithm>
 #include <utility>
 #include <cmath>
+#include <cstdint>
 #include <sstream>
 #include <functional>
 JPH_SUPPRESS_WARNINGS_STD_END
@@ -268,7 +269,7 @@ static_assert(sizeof(void *) == 8, "Invalid size of pointer");
 
 // Stack allocation
 #define JPH_STACK_ALLOC(n)		alloca(n)
-	
+
 // Shorthand for #ifdef _DEBUG / #endif
 #ifdef _DEBUG
 	#define JPH_IF_DEBUG(...)	__VA_ARGS__

--- a/engine/3rdparty/vulkanmemoryallocator/include/vk_mem_alloc.h
+++ b/engine/3rdparty/vulkanmemoryallocator/include/vk_mem_alloc.h
@@ -2565,6 +2565,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
 #ifdef VMA_IMPLEMENTATION
 #undef VMA_IMPLEMENTATION
 
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Archlinux在编译Piccolo时，会遇到 `uint32_t` 等类型不存在的问题，如： #475 

经过检查，发现是由于JoltPhysics和vulkan memory allocator这两个库分别少引用了cstdint和cstdio的问题，导致在archlinux平台无法正常通过编译。

我分别在两个文件中加入了两行#include命令，添加后，Piccolo均可以在我的Archlinux和Windows平台正常通过编译。