### PR TITLE
make JointPhysics dont treat warning as error when compile

### DIFF
--- a/engine/3rdparty/CMakeLists.txt
+++ b/engine/3rdparty/CMakeLists.txt
@@ -70,6 +70,11 @@ if(NOT TARGET Jolt)
             MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
     endif()
 
+    if (MSVC)
+        target_compile_options(Jolt PRIVATE "/W4")
+    else()
+        target_compile_options(Jolt PRIVATE "-Wall")
+    endif()
 endif()
 
 if(NOT TARGET sol2)


### PR DESCRIPTION
Add JointPhysics local warning option to avoid -Werro(/WX) pollute